### PR TITLE
Set up Fuseki to pre-load data

### DIFF
--- a/catalogue-backend/docker-compose.yml
+++ b/catalogue-backend/docker-compose.yml
@@ -1,15 +1,20 @@
 version: "3"
 
-volumes:
-  fuseki_storage:
+# volumes:
+  # fuseki_storage:
 
 services:
   fuseki:
-    image: secoresearch/fuseki
-    volumes:
-      - fuseki_storage:/fuseki-base/databases
+    container_name: cddo-fuseki
+    build:
+      context: fuseki
+      dockerfile: Dockerfile
+    # volumes:
+      # - fuseki_storage:/fuseki-base/databases
     ports:
       - 3030:3030
     environment:
       - ENABLE_UPDATE=true
+      - ENABLE_DATA_WRITE=true
+      - ENABLE_UPLOAD=true
       

--- a/catalogue-backend/fuseki/Dockerfile
+++ b/catalogue-backend/fuseki/Dockerfile
@@ -1,0 +1,10 @@
+FROM secoresearch/fuseki
+
+COPY --chown=9008 data /tmp/data
+
+RUN cat /tmp/data/*.ttl > /tmp/data.ttl
+
+RUN $TDBLOADER --graph=http://dev.data-marketplace.gov.uk/graph/catalogue /tmp/data.ttl 
+RUN $TEXTINDEXER 
+RUN $TDBSTATS --graph urn:x-arq:UnionGraph > /tmp/stats.opt
+RUN mv /tmp/stats.opt /fuseki-base/databases/tdb/

--- a/catalogue-backend/fuseki/data/dwp-address-lookup.ttl
+++ b/catalogue-backend/fuseki/data/dwp-address-lookup.ttl
@@ -1,0 +1,67 @@
+@prefix adms: <https://www.w3.org/ns/adms#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix uk_cross_government_metadata_exchange_model: <https://w3id.org/co-cddo/uk-cross-government-metadata-exchange-model/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://marketplace.cddo.gov.uk/asset/fcbc4d3f-0c05-4857-b0e3-eeec6bfea3a1> a "dcat:DataService"^^xsd:anyURI ;
+    dct:accessRights "INTERNAL" ;
+    dct:creator "department-for-work-pensions" ;
+    dct:description """The location-service provides endpoints to perform a range of address based queries for UK locations. The reference data used is provided by Ordnance Survey and covers Great Britain Northern Ireland and the Channel Islands.
+
+The API currently supports the following functions:
+
+- Postcode Lookup and filtering
+- Fuzzy address searching
+- Unique Property Reference Number (UPRN) lookup
+- Address matching
+- Data provided
+
+## Postcode lookup and fuzzy address search
+
+This endpoint serves as both the standard postcode lookup and the fuzzy lookup. If you call the endpoint with just a search string query parameter the service will perform a fuzzy search against your string and bring back the closest matching results.
+
+For example sending a request to the lookup endpoint with the search string "holy island castle" will return the following address as the top result:
+
+- `NATIONAL TRUST`
+- `LINDISFARNE CASTLE`
+- `HOLY ISLAND`
+- `BERWICK-UPON-TWEED`
+- `TD15 2SH`
+  
+Alternatively if you want to limit your search to a specific postcode you can call the endpoint with the postcode query parameter set. If you call the endpoint with just the postcode then the service will return all addresses for that postcode.
+  
+If you call the endpoint with both postcode and search string the service will return only addresses that match the provided postcode and search string.
+  
+There is also one further parameter for this endpoint (excludeBusiness) which if set will restrict the returned result list to non-commercial addresses.
+  
+## Unique Property Reference Number lookup
+  
+This endpoint will take a unique property reference number (UPRN) as a query parameter and return the specific address record for that ID if present in the data set. As the data set contains a snapshot of current addresses it may be the case that UPRNs which are no longer valid get removed from the data set by Ordnance Survey.
+  
+## Address matching
+  
+This endpoint provides an address matching function. It will take an unstructured address string along with a postcode and try to find an exact match in the data set. If the service can find an exact match then that specific record will be returned. If no match is found then no records are returned. This endpoint also uses fuzzy matching algorithms which allow it to cope with spelling mistakes transposed characters and other errors within the search string.""" ;
+    dct:issued "2022-01-23"^^xsd:date ;
+    dct:license "https://opensource.org/license/isc-license-txt/" ;
+    dct:modified "2023-01-30"^^xsd:date ;
+    dct:publisher "department-for-work-pensions" ;
+    dct:title "Address Lookup" ;
+    dct:type "REST" ;
+    rdfs:comment "DWP single strategic solution for looking up addresses including fuzzy search and UPRN." ;
+    dcat:contactPoint [ a vcard:Kind ;
+            vcard:fn "DWP Integration Team" ;
+            vcard:hasEmail "integration.technologyplatforms@dwp.gsi.gov.uk" ] ;
+    dcat:endpointDescription "https://engineering.dwp.gov.uk/apis/docs"^^xsd:anyURI ;
+    dcat:keyword "Address Search",
+        "UPRN" ;
+    dcat:servesData "https://www.data.gov.uk/dataset/03d48dba-529b-4bd5-93a5-6d41d1b20ff9/national-address-gazetteer"^^xsd:anyURI,
+        "https://www.data.gov.uk/dataset/2dfb82b4-741a-4b93-807e-11abb4bb0875/os-postcodes-data"^^xsd:anyURI,
+        "https://www.data.gov.uk/dataset/92b32629-8ad4-43cb-9952-7d104971fa12/one-scotland-gazetteer"^^xsd:anyURI ;
+    dcat:theme "https://www.data.gov.uk/search?filters%5Btopic%5D=Mapping"^^xsd:anyURI ;
+    dcat:version "2.0.0" ;
+    uk_cross_government_metadata_exchange_model:securityClassification "OFFICIAL" ;
+    adms:status "LIVE" .
+


### PR DESCRIPTION
Any .ttl files in the fuseki/data directory will be automatically loaded into the Fuseki db when the container is re-built

The `dwp-address-lookup.ttl` file was generated from the JSON using LinkML. I had to update the `identifier` to be a URI to get LinkML to not complain, so I added `http://marketplace.cddo.gov.uk/asset/` to the UUID that was already there.

The Fuseki Dockerfile was copied from here:
https://github.com/SemanticComputing/congress-legislators/blob/master/Dockerfile